### PR TITLE
Task 7 -  GET /api/articles/:article_id - Comment Count Property Implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .env.*
 .DS_Store
+output.txt
+commentCount.sql

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -46,16 +46,19 @@ describe("Northcoders News API", () => {
         .expect(200)
         .then(({ _body: { articleData } }) => {
           const articleKeys = Object.keys(articleData[0]);
+          const requestedArticle = articleData[0]
           expect(articleKeys).toHaveLength(7);
-          expect(articleData[0]).toEqual({
-            article_id: 1,
-            title: "Living in the shadow of a great man",
-            topic: "mitch",
-            author: "butter_bridge",
-            body: "I find this existence challenging",
-            created_at: "2020-07-09T20:11:00.000Z",
-            votes: 100,
-          });
+          expect(requestedArticle).toEqual(
+            expect.objectContaining({
+              article_id: 1,
+              title: "Living in the shadow of a great man",
+              topic: "mitch",
+              author: "butter_bridge",
+              body: "I find this existence challenging",
+              created_at: "2020-07-09T20:11:00.000Z",
+              votes: 100,
+            })
+          )
         });
     });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -47,7 +47,7 @@ describe("Northcoders News API", () => {
         .then(({ _body: { articleData } }) => {
           const articleKeys = Object.keys(articleData[0]);
           const requestedArticle = articleData[0]
-          expect(articleKeys).toHaveLength(7);
+          expect(articleKeys).toHaveLength(8);
           expect(requestedArticle).toEqual(
             expect.objectContaining({
               article_id: 1,
@@ -61,6 +61,36 @@ describe("Northcoders News API", () => {
           )
         });
     });
+
+    it('Status: 200 - Should respond with an article corresponding to the article_id of 4 given with the comment count of 0 if no comments', () => {
+      return request(app)
+      .get("/api/articles/4")
+      .expect(200)
+      .then(({_body: { articleData }}) => {
+        const requestedArticle = articleData[0];
+        expect(requestedArticle).toEqual(
+          expect.objectContaining({
+            article_id: 4,
+            comment_count: "0"
+          })
+        )
+      })
+    })
+
+    it('Status: 200 - Should respond with an article corresponding to the article_id of 1 and have a property that has a comment count of 11', () => {
+      return request(app)
+      .get("/api/articles/1")
+      .expect(200)
+      .then(({_body: { articleData }}) => {
+        const requestedArticle = articleData[0];
+        expect(requestedArticle).toEqual(
+          expect.objectContaining({
+            article_id: 1,
+            comment_count: "11"
+          })
+        )
+      })
+    })
 
     it("Status: 400 - Should respond with a message declaring that the parameter passed in is not a number", () => {
       return request(app)

--- a/models/articles-model.js
+++ b/models/articles-model.js
@@ -3,7 +3,7 @@ const db = require('../db/connection');
 exports.fetchArticleByID = (article_id) => {
     return db
     .query(`
-    SELECT articles.article_id, title, topic, articles.author, articles.body, articles.created_at, articles.votes, COUNT(comments.author) AS comment_count
+    SELECT articles.*, COUNT(comments.author) AS comment_count
     FROM articles
     LEFT JOIN comments
     ON articles.article_id = comments.article_id

--- a/models/articles-model.js
+++ b/models/articles-model.js
@@ -2,7 +2,14 @@ const db = require('../db/connection');
 
 exports.fetchArticleByID = (article_id) => {
     return db
-    .query(`SELECT * FROM articles WHERE article_id = $1`, [article_id])
+    .query(`
+    SELECT articles.article_id, title, topic, articles.author, articles.body, articles.created_at, articles.votes, COUNT(comments.author) AS comment_count
+    FROM articles
+    LEFT JOIN comments
+    ON articles.article_id = comments.article_id
+    WHERE articles.article_id = $1
+    GROUP BY articles.article_id  
+    `, [article_id])
     .then(({rows: articleData}) => {
         if(articleData.length === 0) {
             return Promise.reject({status: 404, msg: 'Article not found'});


### PR DESCRIPTION
For this PR I have done the following: 

1. Adjusted the original test for task 3 that checked for strict equality using "toEqual" to an "expect.objectContaining" so that task 7's implementation of the "comment_count" property will still have Task 3's test pass.
2. Added to the .gitignore file the utility files created for SQL queries.
3. Added the solution to the /models/articles-model.js
4. Added appropriate tests for two different articles with differing ids (1 & 4) that have differing comment counts (11, 0)
 